### PR TITLE
Patching schema bug

### DIFF
--- a/radarpipeline/io/reader.py
+++ b/radarpipeline/io/reader.py
@@ -256,13 +256,15 @@ class AvroSchemaReader(SchemaReader):
             A Spark data type
         """
         if type(data_type) is list:
-            if len(data_type) == 1:
-                return self.data_type_mapping[data_type[0]]
+            data_type.remove("null")
+            if len(data_type) == 1 and data_type[0] in self.data_type_mapping:
+                data_type  = data_type[0]
             else:
-                return StringType()
-        elif type(data_type) is str and data_type in self.data_type_mapping:
+                data_type = "string"
+        if data_type in self.data_type_mapping:
             return self.data_type_mapping[data_type]
         elif type(data_type) is dict:
             return StringType()
         else:
-            raise ValueError(f"Unknown data type: {data_type}")
+            logger.warning(f"Unknown data type: {data_type}. Returning String type.")
+            return StringType()


### PR DESCRIPTION
Patch Schema bug for now. 

There are two sorts of issues. 

1. List of data types present in AVRO schema. 

In some cases, the schema type is `["null", "double"]`. In those cases, I have removed the `null` datatype from the list and check if there's more than one element in the list. If that's the case, then we return string otherwise we'll return the only remaining element. 

2. array data type in AVRO schema

In some cases, there's an `array` data type available in the schema. Spark does support [Array Schema type ](https://spark.apache.org/docs/latest/sql-ref-datatypes.html) but [it wouldn't be support if the file is CSV.](https://mungingdata.com/pyspark/array-arraytype-list/). So currently I am returning string data type instead which would work for now. 