### PR TITLE
Removed Spark Logs coming from Java

### DIFF
--- a/radarpipeline/radarpipeline.py
+++ b/radarpipeline/radarpipeline.py
@@ -4,11 +4,17 @@ import traceback
 
 from radarpipeline import Project
 from radarpipeline.common.logger import logger_init
+from pyspark.sql import SparkSession
 
 logger_init()
 
 logger = logging.getLogger(__name__)
 
+spark = SparkSession.builder.\
+        master('local').\
+        appName('foo').\
+        getOrCreate()
+spark.sparkContext.setLogLevel('WARN')
 
 def run():
     """


### PR DESCRIPTION
issue:Remove Spark Logs coming from Java from the Pipeline Logs #38
solution: imported Sparksession from pyspark.sql and utilised setLogLevel for 'WARN'
<img width="682" alt="Screenshot 2023-01-19 at 3 32 21 PM" src="https://user-images.githubusercontent.com/85059599/2134178
<img width="745" alt="Screenshot 2023-01-19 at 3 35 12 PM" src="https://user-images.githubusercontent.com/85059599/213417909-06f58bdc-9402-4b0c-8a85-72b37dad8d6b.png">
67-3cfa82b0-8282-497d-b9b4-b5a8b4cb65bd.png">
